### PR TITLE
fix(pgbackrest): Do not schedule backups at boot

### DIFF
--- a/roles/pgbackrest/molecule/default/verify.yml
+++ b/roles/pgbackrest/molecule/default/verify.yml
@@ -21,6 +21,24 @@
         cmd: pgbackrest check
       changed_when: false
 
+    - name: Check full backup service
+      ansible.builtin.systemd:
+        name: pgbackrest-full.service
+      register: pgbackrest_full_service
+
+    - name: Verify that full backup service will not start at boot
+      ansible.builtin.assert:
+        that: pgbackrest_full_service.status.UnitFileState == "disabled"
+
+    - name: Check diff backup service
+      ansible.builtin.systemd:
+        name: pgbackrest-diff.service
+      register: pgbackrest_diff_service
+
+    - name: Verify that diff backup service will not start at boot
+      ansible.builtin.assert:
+        that: pgbackrest_diff_service.status.UnitFileState == "disabled"
+
     - name: Start a full backup
       ansible.builtin.service:
         name: pgbackrest-full.service

--- a/roles/pgbackrest/tasks/configure_schedules.yml
+++ b/roles/pgbackrest/tasks/configure_schedules.yml
@@ -15,7 +15,7 @@
 - name: Manage schedules services
   ansible.builtin.service:
     name: "pgbackrest-{{ backup_type }}.service"
-    enabled: true
+    enabled: false
   loop: "{{ pgbackrest_schedules.keys() }}"
   loop_control:
     loop_var: backup_type


### PR DESCRIPTION
After a reboot, do not start pgbackrest-full and pgbackrest-diff services. They should be started exclusively by their respective timers.

Fixes #9.